### PR TITLE
Added Criteria pattern.

### DIFF
--- a/src/Domain/Criteria/Criteria.php
+++ b/src/Domain/Criteria/Criteria.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OtherCode\ComplexHeart\Domain\Criteria;
+
+use OtherCode\ComplexHeart\Domain\Contracts\ValueObject;
+use OtherCode\ComplexHeart\Domain\Traits\IsValueObject;
+
+/**
+ * Class Criteria
+ *
+ * @author Unay Santisteban <usantisteban@othercode.es>
+ * @package OtherCode\ComplexHeart\Domain\Criteria
+ */
+final class Criteria implements ValueObject
+{
+    use IsValueObject;
+
+    /**
+     * The filters collection.
+     *
+     * @var FilterGroup
+     */
+    private FilterGroup $filters;
+
+    /**
+     * Criteria order statement.
+     *
+     * @var Order
+     */
+    private Order $order;
+
+    /**
+     * Criteria pagination.
+     *
+     * @var Page
+     */
+    private Page $page;
+
+    /**
+     * Criteria constructor.
+     *
+     * @param  FilterGroup<Filter>  $filters
+     * @param  Order  $order
+     * @param  Page  $page
+     */
+    public function __construct(FilterGroup $filters, Order $order, Page $page)
+    {
+        $this->initialize(['filters' => $filters, 'order' => $order, 'page' => $page]);
+    }
+
+    public function filters(): FilterGroup
+    {
+        return $this->filters;
+    }
+
+    public function order(): Order
+    {
+        return $this->order;
+    }
+
+    public function orderBy(): string
+    {
+        return $this->order->by();
+    }
+
+    public function orderType(): string
+    {
+        return $this->order->type();
+    }
+
+    public function page(): Page
+    {
+        return $this->page;
+    }
+
+    public function pageOffset(): int
+    {
+        return $this->page->offset();
+    }
+
+    public function pageLimit(): int
+    {
+        return $this->page->limit();
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('%s#%s#%s', $this->filters, $this->order, $this->page);
+    }
+}

--- a/src/Domain/Criteria/Filter.php
+++ b/src/Domain/Criteria/Filter.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OtherCode\ComplexHeart\Domain\Criteria;
+
+use ReflectionClass;
+use OtherCode\ComplexHeart\Domain\Contracts\ValueObject;
+use OtherCode\ComplexHeart\Domain\Traits\IsValueObject;
+
+/**
+ * Class Filter
+ *
+ * @author Unay Santisteban <usantisteban@othercode.es>
+ * @package OtherCode\ComplexHeart\Domain\Criteria
+ */
+final class Filter implements ValueObject
+{
+    use IsValueObject;
+
+    public const EQUAL = '=';
+    public const NOT_EQUAL = '!=';
+    public const GT = '>';
+    public const GTE = '>=';
+    public const LT = '<';
+    public const LTE = '<=';
+    public const IN = 'in';
+    public const NOT_IN = 'notIn';
+
+    /**
+     * The filter field name.
+     *
+     * @var string
+     */
+    private string $field;
+
+    /**
+     * The filter operator.
+     *
+     * @var string
+     */
+    private string $operator;
+
+    /**
+     * The filter field value.
+     *
+     * @var string
+     */
+    private string $value;
+
+    /**
+     * Internal cache.
+     *
+     * @var array
+     */
+    protected static array $cache = [];
+
+    /**
+     * Filter constructor.
+     *
+     * @param  string  $field
+     * @param  string  $operator
+     * @param  string  $value
+     */
+    public function __construct(string $field, string $operator, string $value)
+    {
+        $this->initialize(['field' => $field, 'operator' => $operator, 'value' => $value]);
+    }
+
+    final protected function invariantFieldValueMustNotBeEmptyString(): bool
+    {
+        return !empty($this->field);
+    }
+
+    final protected function invariantOperatorValueMustBeOneOfTheList(): bool
+    {
+        if (!isset(self::$cache[self::class])) {
+            self::$cache[self::class] = (new ReflectionClass(self::class))->getConstants();
+        }
+
+        return in_array($this->operator, self::$cache[self::class], true);
+    }
+
+    /**
+     * Named constructor, create a new Filter object.
+     *
+     * @param  string  $field
+     * @param  string  $operator
+     * @param  string  $value
+     *
+     * @return Filter
+     */
+    public static function create(string $field, string $operator, string $value): Filter
+    {
+        return new self($field, $operator, $value);
+    }
+
+    /**
+     * Retrieve the filter field value object.
+     *
+     * @return string
+     */
+    public function field(): string
+    {
+        return $this->field;
+    }
+
+    public function operator(): string
+    {
+        return $this->operator;
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('%s.%s.%s', $this->field(), $this->operator(), $this->value());
+    }
+}

--- a/src/Domain/Criteria/FilterGroup.php
+++ b/src/Domain/Criteria/FilterGroup.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OtherCode\ComplexHeart\Domain\Criteria;
+
+use Countable;
+use OtherCode\ComplexHeart\Domain\Contracts\ValueObject;
+use OtherCode\ComplexHeart\Domain\Traits\IsValueObject;
+
+/**
+ * Class FilterGroup
+ *
+ * @author Unay Santisteban <usantisteban@othercode.es>
+ * @package OtherCode\ComplexHeart\Domain\Criteria
+ */
+final class FilterGroup implements ValueObject, Countable
+{
+    use IsValueObject;
+
+    /**
+     * List of filter in the group.
+     *
+     * @var Filter[]
+     */
+    private array $filters;
+
+    /**
+     * FilterGroup constructor.
+     *
+     * @param  Filter  ...$filters
+     */
+    public function __construct(Filter ...$filters)
+    {
+        $this->initialize(['filters' => $filters]);
+    }
+
+    public static function create(array $filters): FilterGroup
+    {
+        return new self(...array_map(fn(array $filter) => Filter::create(...$filter), $filters));
+    }
+
+    public function add(Filter $filter): FilterGroup
+    {
+        return new self(array_merge($this->filters, [$filter]));
+    }
+
+    public function filters(): array
+    {
+        return $this->filters;
+    }
+
+    public function count(): int
+    {
+        return count($this->filters);
+    }
+
+    public function __toString(): string
+    {
+        return implode('+', $this->filters);
+    }
+}

--- a/src/Domain/Criteria/Order.php
+++ b/src/Domain/Criteria/Order.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OtherCode\ComplexHeart\Domain\Criteria;
+
+use OtherCode\ComplexHeart\Domain\Contracts\ValueObject;
+use OtherCode\ComplexHeart\Domain\Traits\IsValueObject;
+
+/**
+ * Class Order
+ *
+ * @author Unay Santisteban <usantisteban@othercode.es>
+ * @package OtherCode\ComplexHeart\Domain\Criteria
+ */
+final class Order implements ValueObject
+{
+    use IsValueObject;
+
+    private const ORDER_TYPE_ASC = 'asc';
+    private const ORDER_TYPE_DESC = 'desc';
+    private const ORDER_TYPE_NONE = 'none';
+
+    /**
+     * Used to sort the result-set by specific field.
+     *
+     * @var string
+     */
+    private string $by;
+
+    /**
+     * Used to sort the result-set in ascending or descending order. Ascending order by default.
+     *
+     * @var string
+     */
+    private string $type;
+
+    /**
+     * Order constructor.
+     *
+     * @param  string  $by
+     * @param  string  $type
+     */
+    public function __construct(string $by, string $type = self::ORDER_TYPE_ASC)
+    {
+        $this->initialize(["by" => $by, "type" => $type]);
+    }
+
+    final protected function invariantOrderByValueMustContainOnlyAlphanumericalCharacters(): bool
+    {
+        return preg_match('/\w*/', $this->by) === 1;
+    }
+
+    final protected function invariantOrderTypeValueMustBeOneOfAscDescOrNone(): bool
+    {
+        return in_array(
+            $this->type,
+            [self::ORDER_TYPE_ASC, self::ORDER_TYPE_DESC, self::ORDER_TYPE_NONE]
+        );
+    }
+
+    public static function create(string $by, string $type = self::ORDER_TYPE_ASC): Order
+    {
+        return new self($by, $type);
+    }
+
+    public static function none(): Order
+    {
+        return self::create('', self::ORDER_TYPE_NONE);
+    }
+
+    public function by(): string
+    {
+        return $this->by;
+    }
+
+    public function type(): string
+    {
+        return $this->type;
+    }
+
+    public function isNone(): bool
+    {
+        return $this->type === self::ORDER_TYPE_NONE;
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('%s.%s', $this->by(), $this->type());
+    }
+}

--- a/src/Domain/Criteria/Page.php
+++ b/src/Domain/Criteria/Page.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OtherCode\ComplexHeart\Domain\Criteria;
+
+use OtherCode\ComplexHeart\Domain\Contracts\ValueObject;
+use OtherCode\ComplexHeart\Domain\Traits\IsValueObject;
+
+/**
+ * Class Page
+ *
+ * @author Unay Santisteban <usantisteban@othercode.es>
+ * @package OtherCode\ComplexHeart\Domain\Criteria
+ */
+final class Page implements ValueObject
+{
+    use IsValueObject;
+
+    /**
+     * Specifies the maximum number of items to return.
+     *
+     * @var int
+     */
+    private int $limit;
+
+    /**
+     * Specifies the offset of the first item to return.
+     *
+     * @var int
+     */
+    private int $offset;
+
+    /**
+     * Page constructor.
+     *
+     * @param  int  $limit
+     * @param  int  $offset
+     */
+    public function __construct(int $limit = 1000, int $offset = 0)
+    {
+        $this->initialize(['limit' => $limit, 'offset' => $offset]);
+    }
+
+    public static function create(int $limit = 1000, int $offset = 0): Page
+    {
+        return new self($limit, $offset);
+    }
+
+    final protected function invariantLimitValueMustBePositive(): bool
+    {
+        return $this->limit >= 0;
+    }
+
+    final protected function invariantOffsetValueMustBePositive(): bool
+    {
+        return $this->offset >= 0;
+    }
+
+    public function limit(): int
+    {
+        return $this->limit;
+    }
+
+    public function offset(): int
+    {
+        return $this->offset;
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('%s.%s', $this->limit, $this->offset);
+    }
+}

--- a/tests/Domain/Criteria/CriteriaTest.php
+++ b/tests/Domain/Criteria/CriteriaTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OtherCode\ComplexHeart\Tests\Domain\Criteria;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use OtherCode\ComplexHeart\Domain\Criteria\Criteria;
+use OtherCode\ComplexHeart\Domain\Criteria\FilterGroup;
+use OtherCode\ComplexHeart\Domain\Criteria\Order;
+use OtherCode\ComplexHeart\Domain\Criteria\Page;
+
+/**
+ * Class CriteriaTest
+ *
+ * @author Unay Santisteban <usantisteban@othercode.es>
+ * @package OtherCode\ComplexHeart\Tests\Domain\Criteria
+ */
+class CriteriaTest extends MockeryTestCase
+{
+    public function testShouldBuildCriteriaSuccessfully(): void
+    {
+        $criteria = new Criteria(
+            FilterGroup::create(
+                [
+                    ['name', '=', 'Marsellus'],
+                    ['surname', '=', 'Wallace'],
+                ]
+            ),
+            Order::create('name'),
+            Page::create(100, 100)
+        );
+
+        $this->assertCount(2, $criteria->filters());
+        $this->assertCount(2, $criteria->filters()->filters());
+
+        $this->assertInstanceOf(Order::class, $criteria->order());
+        $this->assertEquals('name', $criteria->orderBy());
+        $this->assertEquals('asc', $criteria->orderType());
+        $this->assertFalse($criteria->order()->isNone());
+
+        $this->assertInstanceOf(Page::class, $criteria->page());
+        $this->assertEquals(100, $criteria->pageLimit());
+        $this->assertEquals(100, $criteria->pageOffset());
+
+        $this->assertEquals(
+            "name.=.Marsellus+surname.=.Wallace#name.asc#100.100",
+            (string)$criteria
+        );
+    }
+}


### PR DESCRIPTION
Example of usage:

```php
$criteria = new Criteria(
    FilterGroup::create(
        [
            ['name', '=', 'Marsellus'],
            ['surname', '=', 'Wallace'],
        ]
    ),
    Order::create('name'),
    Page::create(100, 100)
);
```

Can be used along with `Finders`:

```php
$finder->byCriteria($criteria);
```
