### PR TITLE
Feature/Add `is` method to Identifier contract.

### DIFF
--- a/src/Domain/Contracts/Identifier.php
+++ b/src/Domain/Contracts/Identifier.php
@@ -20,4 +20,13 @@ interface Identifier
      * @return string
      */
     public function value(): string;
+
+    /**
+     * Check if the given identifier is the same than the current one.
+     *
+     * @param  Identifier  $other
+     *
+     * @return bool
+     */
+    public function is(Identifier $other): bool;
 }

--- a/src/Domain/ValueObjects/UUIDValue.php
+++ b/src/Domain/ValueObjects/UUIDValue.php
@@ -73,6 +73,18 @@ class UUIDValue implements ValueObject, Identifier
     }
 
     /**
+     * Check if the given identifier is the same than the current one.
+     *
+     * @param  Identifier  $other
+     *
+     * @return bool
+     */
+    public function is(Identifier $other): bool
+    {
+        return $this->equals($other);
+    }
+
+    /**
      * To string method.
      *
      * @return string


### PR DESCRIPTION
- Now it is possible to use `is()` method to check if two identifiers are the same.

```php
$id->is($that); // true or false
```