### PR TITLE
Feature/Added wakeup method to create instances without call explicitly the constructor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners.
+*       @othercodes

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "nesbot/carbon": "^2.40",
     "illuminate/collections": "^8.20",
     "spatie/data-transfer-object": "^2.6",
-    "lambdish/phunctional": "^2.1"
+    "lambdish/phunctional": "^2.1",
+    "doctrine/instantiator": "^1.4"
   },
   "require-dev": {
     "mockery/mockery": "^1.4",

--- a/src/Domain/Traits/IsModel.php
+++ b/src/Domain/Traits/IsModel.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace OtherCode\ComplexHeart\Domain\Traits;
 
+use RuntimeException;
+use Doctrine\Instantiator\Instantiator;
+use Doctrine\Instantiator\Exception\ExceptionInterface;
+
 /**
  * Trait IsModel
  *
@@ -19,10 +23,54 @@ trait IsModel
      *
      * @param  array  $source
      * @param  callable|null  $onFail
+     *
+     * @return static
      */
-    protected function initialize(array $source, callable $onFail = null): void
+    protected function initialize(array $source, callable $onFail = null)
     {
-        $this->hydrate($source);
+        $this->hydrate($this->mapSource($source));
         $this->check($onFail);
+
+        return $this;
+    }
+
+    /**
+     * Restore the instance without calling __constructor of the model.
+     *
+     * @return static
+     *
+     * @throws RuntimeException
+     */
+    public static function wakeup()
+    {
+        try {
+            return (new Instantiator())
+                ->instantiate(static::class)
+                ->initialize(func_get_args());
+        } catch (ExceptionInterface $e) {
+            throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * Map the given source with the actual attributes by position, if
+     * the provided array is already mapped (assoc) return it directly.
+     *
+     * @param  array  $source
+     *
+     * @return array
+     */
+    protected function mapSource(array $source): array
+    {
+        // check if the array is indexed or associative.
+        $isIndexed = fn($source): bool => [] === $source
+            ? false
+            : array_keys($source) === range(0, count($source) - 1);
+
+        return $isIndexed($source)
+            // combine the attributes keys with the provided source values.
+            ? array_combine(array_slice(static::attributes(), 0, count($source)), $source)
+            // return the already mapped array source.
+            : $source;
     }
 }

--- a/tests/Domain/Traits/HasDomainEventTest.php
+++ b/tests/Domain/Traits/HasDomainEventTest.php
@@ -29,14 +29,35 @@ class HasDomainEventTest extends MockeryTestCase
             ->once()
             ->with(Mockery::type(Event::class));
 
-        $o = Order::create(
+        $o = new Order(
             UUIDValue::random(),
             new PaymentStatus(PaymentStatus::PENDING),
-            new OrderLine(UUIDValue::random(), new ProductName('PR 1')),
-            new OrderLine(UUIDValue::random(), new ProductName('PR 2')),
+            [
+                new OrderLine(UUIDValue::random(), new ProductName('PR 1')),
+                new OrderLine(UUIDValue::random(), new ProductName('PR 2'))
+            ]
         );
 
         $this->assertCount(1, $o->getDomainEvents());
+        $o->publishDomainEvents($eventBus);
+        $this->assertCount(0, $o->getDomainEvents());
+    }
+
+    public function testShouldNotAddDomainEvent(): void
+    {
+        $eventBus = Mockery::mock(EventBus::class);
+        $eventBus->shouldReceive('publish')->with(...[]);
+
+        $o = Order::wakeup(
+            UUIDValue::random(),
+            new PaymentStatus(PaymentStatus::PENDING),
+            [
+                new OrderLine(UUIDValue::random(), new ProductName('PR 1')),
+                new OrderLine(UUIDValue::random(), new ProductName('PR 2'))
+            ]
+        );
+
+        $this->assertCount(0, $o->getDomainEvents());
         $o->publishDomainEvents($eventBus);
         $this->assertCount(0, $o->getDomainEvents());
     }

--- a/tests/Sample/Order.php
+++ b/tests/Sample/Order.php
@@ -6,6 +6,7 @@ namespace OtherCode\ComplexHeart\Tests\Sample;
 
 use Exception;
 use OtherCode\ComplexHeart\Domain\Contracts\Aggregate;
+use OtherCode\ComplexHeart\Domain\Exceptions\InvariantViolation;
 use OtherCode\ComplexHeart\Domain\Traits\IsAggregate;
 use OtherCode\ComplexHeart\Domain\ValueObjects\UUIDValue as OrderId;
 use OtherCode\ComplexHeart\Tests\Sample\Events\OrderHasBeenCreated;
@@ -33,10 +34,30 @@ final class Order implements Aggregate
      * @param  OrderId  $id
      * @param  PaymentStatus  $status
      * @param  OrderLine  ...$orderLines
+     *
+     * @throws Exception
      */
-    public function __construct(OrderId $id, PaymentStatus $status, OrderLine ...$orderLines)
+    public function __construct(OrderId $id, PaymentStatus $status, array $orderLines)
     {
-        $this->initialize(['id' => $id, 'status' => $status, 'orderLines' => $orderLines]);
+        $this->initialize([$id, $status, $orderLines]);
+        $this->registerDomainEvent(new OrderHasBeenCreated($this->id()->value()));
+    }
+
+    /**
+     * Invariant, check that all items in order line array are type of OrderLine.
+     *
+     * @return bool
+     * @throws InvariantViolation
+     */
+    protected function invariantEachOrderLineMustBeTypeOfOrderLine(): bool
+    {
+        foreach ($this->orderLines as $orderLine) {
+            if (!($orderLine instanceof OrderLine)) {
+                throw new InvariantViolation("All order lines must be type of OrderLine");
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -49,13 +70,9 @@ final class Order implements Aggregate
      * @return static
      * @throws Exception
      */
-    public static function create(OrderId $id, PaymentStatus $status, OrderLine ...$orderLines): self
+    public static function create(OrderId $id, PaymentStatus $status, array $orderLines): self
     {
-        $order = new self($id, $status, ...$orderLines);
-
-        $order->registerDomainEvent(new OrderHasBeenCreated($order->id()->value()));
-
-        return $order;
+        return new self($id, $status, $orderLines);
     }
 
     /**


### PR DESCRIPTION
Creating an instance with `new` keyword will execute the logic inside the `__constructor()` but using `::wakeup()` will create the instance, and fill the properties without executing the logic in the `__constructor()`. 

So, having and aggregate `Order` that registers the domain event `OrderCreated` in the constructor:

```php
final class Order implements Aggregate
{
    use IsAggregate;

    private OrderId $id;
    private PaymentStatus $status;
    private array $orderLines;

    public function __construct(OrderId $id, PaymentStatus $status, array $orderLines)
    {
        $this->initialize([$id, $status, $orderLines]);
        $this->registerDomainEvent(new OrderCreated($this->id()->value()));
    }

    protected function invariantEachOrderLineMustBeTypeOfOrderLine(): bool
    {
        foreach ($this->orderLines as $orderLine) {
            if (!($orderLine instanceof OrderLine)) {
                throw new InvariantViolation("All order lines must be type of OrderLine");
            }
        }

        return true;
    }

    public static function create(OrderId $id, PaymentStatus $status, array $orderLines): self
    {
        return new self($id, $status, $orderLines);
    }
}

```

 we can do:  

```php
// OrderCreated domain event is register since is register in __constructor().
$a = new Order(...) 

// aggregate constructor is NOT called so the domain event is not registered,
// initialize() is called so the invariants are also checked.
$a = Order::wakeup(...) 
```

This makes the usage of `new` more semantic as we are creating a REAL new instance of the Aggregate not just creating an object, we may need to register some domain events on the creation of the Aggregate.
