### PR TITLE
Release v0.4.1

### DIFF
--- a/src/Application/CriteriaBuilder.php
+++ b/src/Application/CriteriaBuilder.php
@@ -216,7 +216,7 @@ final class CriteriaBuilder
     {
         return new Criteria(
             FilterGroup::create($this->filters),
-            Order::create($this->orderBy, $this->orderType),
+            empty($this->orderBy) ? Order::none() : Order::create($this->orderBy, $this->orderType),
             Page::create($this->pageLimit, $this->pageOffset)
         );
     }


### PR DESCRIPTION
Bugfix/Make sure that criteria builder builds criteria with `order = none` by default (#29)