### PR TITLE
Feature/Optimizations

### DIFF
--- a/src/Domain/Traits/HasAttributes.php
+++ b/src/Domain/Traits/HasAttributes.php
@@ -15,6 +15,12 @@ use function Lambdish\Phunctional\map;
 trait HasAttributes
 {
     /**
+     * Static property to keep cached attributes list to optimize performance.
+     * @var array<string, mixed>
+     */
+    private static array $_attributesCache;
+
+    /**
      * Return the list of attributes of the current class.
      * Properties starting with "_" will be considered as internal use only.
      *
@@ -22,10 +28,13 @@ trait HasAttributes
      */
     final public static function attributes(): array
     {
-        return array_filter(
-            array_keys(get_class_vars(static::class)),
-            fn(string $item) => strpos($item, '_') !== 0
-        );
+        if (empty(static::$_attributesCache)) {
+            static::$_attributesCache = array_filter(
+                array_keys(get_class_vars(static::class)),
+                fn(string $item) => strpos($item, '_') !== 0
+            );
+        }
+        return static::$_attributesCache;
     }
 
     /**

--- a/src/Domain/Traits/HasAttributes.php
+++ b/src/Domain/Traits/HasAttributes.php
@@ -16,9 +16,9 @@ trait HasAttributes
 {
     /**
      * Static property to keep cached attributes list to optimize performance.
-     * @var array<string, mixed>
+     * @var array<array<string, mixed>>
      */
-    private static array $_attributesCache;
+    private static array $_attributesCache = [];
 
     /**
      * Static property to keep cached string keys to optimize performance
@@ -34,13 +34,13 @@ trait HasAttributes
      */
     final public static function attributes(): array
     {
-        if (empty(static::$_attributesCache)) {
-            static::$_attributesCache = array_filter(
+        if (empty(static::$_attributesCache[static::class])) {
+            static::$_attributesCache[static::class] = array_filter(
                 array_keys(get_class_vars(static::class)),
                 fn(string $item) => strpos($item, '_') !== 0
             );
         }
-        return static::$_attributesCache;
+        return static::$_attributesCache[static::class];
     }
 
     /**

--- a/src/Domain/Traits/HasAttributes.php
+++ b/src/Domain/Traits/HasAttributes.php
@@ -21,6 +21,12 @@ trait HasAttributes
     private static array $_attributesCache;
 
     /**
+     * Static property to keep cached string keys to optimize performance
+     * @var array<string, string>
+     */
+    private static array $_stringKeysCache = [];
+
+    /**
      * Return the list of attributes of the current class.
      * Properties starting with "_" will be considered as internal use only.
      *
@@ -117,12 +123,16 @@ trait HasAttributes
      */
     protected function getStringKey(string $id, string $prefix = '', string $suffix = ''): string
     {
-        return sprintf(
-            '%s%s%s',
-            $prefix,
-            implode('', map(fn(string $chunk) => ucfirst($chunk), explode('_', $id))),
-            $suffix
-        );
+        $cacheKey = implode('-', [$id, $prefix, $suffix]);
+        if (empty(static::$_stringKeysCache[$cacheKey])) {
+            static::$_stringKeysCache[$cacheKey] = sprintf(
+                '%s%s%s',
+                $prefix,
+                implode('', map(fn(string $chunk) => ucfirst($chunk), explode('_', $id))),
+                $suffix
+            );
+        }
+        return static::$_stringKeysCache[$cacheKey];
     }
 
     /**

--- a/src/Domain/Traits/HasInvariants.php
+++ b/src/Domain/Traits/HasInvariants.php
@@ -19,6 +19,12 @@ use function Lambdish\Phunctional\filter;
 trait HasInvariants
 {
     /**
+     * Static property to keep cached invariants list to optimize performance.
+     * @var array<string, <string, mixed>>
+     */
+    private static $_invariantsCache = [];
+
+    /**
      * Invariant configuration.
      *
      * - exception: Defines the exception that will be thrown on invariant violation.
@@ -40,20 +46,25 @@ trait HasInvariants
      */
     final public static function invariants(): array
     {
-        $invariants = [];
-        foreach (get_class_methods(static::class) as $invariant) {
-            if (strpos($invariant, 'invariant') === 0 && $invariant !== 'invariants') {
-                $invariants[$invariant] = str_replace(
-                    'invariant ',
-                    '',
-                    strtolower(
-                        preg_replace('/[A-Z]([A-Z](?![a-z]))*/', ' $0', $invariant)
-                    )
-                );
+        if (empty(static::$_invariantsCache[static::class])) {
+            $invariants = [];
+
+            foreach (get_class_methods(static::class) as $invariant) {
+                if (strpos($invariant, 'invariant') === 0 && $invariant !== 'invariants') {
+                    $invariants[$invariant] = str_replace(
+                        'invariant ',
+                        '',
+                        strtolower(
+                            preg_replace('/[A-Z]([A-Z](?![a-z]))*/', ' $0', $invariant)
+                        )
+                    );
+                }
             }
+
+            static::$_invariantsCache[static::class] = $invariants;
         }
 
-        return $invariants;
+        return static::$_invariantsCache[static::class];
     }
 
     /**


### PR DESCRIPTION
Memoize some internal methods results in order to optimize performance. Per single instance the benefit is quite small, but, when is necessary to operate the big amount of instances - the benefit is significant. I've created benchmark and here is the result before optimization:
```
dmytro@DESKTOP-GHVMRBF:~/work/api.premiervirtual.com$ ./development php artisan benchmark:aggregate-vs-eloquent --batchSize=1000 --limit=10000
 10000/10000 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
Execution time: 6.1068408489227 seconds
Consumed RAM: 36Mb
dmytro@DESKTOP-GHVMRBF:~/work/api.premiervirtual.com$ ./development php artisan benchmark:aggregate-vs-eloquent --batchSize=1000 --limit=10000
 10000/10000 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
Execution time: 5.9404318332672 seconds
Consumed RAM: 36Mb
dmytro@DESKTOP-GHVMRBF:~/work/api.premiervirtual.com$ ./development php artisan benchmark:aggregate-vs-eloquent --batchSize=1000 --limit=10000
 10000/10000 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
Execution time: 6.0607869625092 seconds
Consumed RAM: 36Mb
```

And this is result after optimization:

```
dmytro@DESKTOP-GHVMRBF:~/work/api.premiervirtual.com$ ./development php artisan benchmark:aggregate-vs-eloquent --batchSize=1000 --limit=10000
 10000/10000 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
Execution time: 3.582909822464 seconds
Consumed RAM: 36Mb
dmytro@DESKTOP-GHVMRBF:~/work/api.premiervirtual.com$ ./development php artisan benchmark:aggregate-vs-eloquent --batchSize=1000 --limit=10000
 10000/10000 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
Execution time: 3.6363780498505 seconds
Consumed RAM: 36Mb
dmytro@DESKTOP-GHVMRBF:~/work/api.premiervirtual.com$ ./development php artisan benchmark:aggregate-vs-eloquent --batchSize=1000 --limit=10000
 10000/10000 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
Execution time: 3.5810899734497 seconds
Consumed RAM: 36Mb
dmytro@DESKTOP-GHVMRBF:~/work/api.premiervirtual.com$
```