### PR TITLE
Bugfix/Make ArrayValue implementation compatible with the PHP8.1 and above

### DIFF
--- a/src/Domain/ValueObjects/ArrayValue.php
+++ b/src/Domain/ValueObjects/ArrayValue.php
@@ -187,6 +187,11 @@ abstract class ArrayValue extends Value implements IteratorAggregate, ArrayAcces
         return serialize($this->value);
     }
 
+    public function __serialize(): array
+    {
+        return $this->value;
+    }
+
     /**
      * Constructs the object.
      *
@@ -195,6 +200,11 @@ abstract class ArrayValue extends Value implements IteratorAggregate, ArrayAcces
     public function unserialize($serialized): void
     {
         $this->value = unserialize($serialized);
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->value = $data;
     }
 
     /**

--- a/tests/Domain/ValueObjects/ArrayValueTest.php
+++ b/tests/Domain/ValueObjects/ArrayValueTest.php
@@ -63,4 +63,14 @@ class ArrayValueTest extends MockeryTestCase
             $this->assertIsString($item);
         }
     }
+
+    public function testShouldBeSerializable(): void
+    {
+        $vo = new ShoppingList(['Milk', 'Eggs', 'Yogurt']);
+        $unserialized = unserialize(serialize($vo));
+
+        foreach ($vo as $item) {
+            $this->assertContains($item, $unserialized);
+        }
+    }
 }


### PR DESCRIPTION
Since PHP version 8.1 any `Serializable` interface implementation must have magic methods `__serialize` and `__unserialize`
[Here](https://php.watch/versions/8.1/serializable-deprecated) is more info.