### PR TITLE
Optimization/Invariants checking

### DIFF
--- a/src/Domain/Traits/HasInvariants.php
+++ b/src/Domain/Traits/HasInvariants.php
@@ -46,7 +46,7 @@ trait HasInvariants
      */
     final public static function invariants(): array
     {
-        if (empty(static::$_invariantsCache[static::class])) {
+        if (array_key_exists(static::class, static::$_invariantsCache) === false) {
             $invariants = [];
 
             foreach (get_class_methods(static::class) as $invariant) {

--- a/src/Domain/Traits/HasInvariants.php
+++ b/src/Domain/Traits/HasInvariants.php
@@ -91,6 +91,10 @@ trait HasInvariants
      */
     private function check(callable $filter = null, callable $onFail = null): void
     {
+        if ($this->skipChecking()) {
+            return;
+        }
+
         $violations = [];
 
         $invariants = filter(
@@ -131,5 +135,11 @@ trait HasInvariants
 
             $onFail($violations);
         }
+    }
+
+    private function skipChecking(): bool
+    {
+        $key = 'COMPLEX_HEARTH_SKIP_INVARIANTS_CHECKING';
+        return (bool)($_ENV[$key] ?? getenv($key));
     }
 }


### PR DESCRIPTION
- Fix issue with repetitive invariants resolving in case model has empty invariants list
- Allow to disable invariants checking by setting the environment variable `COMPLEX_HEARTH_SKIP_INVARIANTS_CHECKING` to any value which can be casted to `true`